### PR TITLE
Add server and Render deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# AI Factory Deployment on Render.com
+
+This repository contains a React application. The project is bundled into the `dist` directory and served with a small Express server. The following steps describe how to run the app locally and deploy it on [Render](https://render.com).
+
+## Local development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Build the React project (replace the command with your actual build process if different):
+   ```bash
+   npm run build
+   ```
+3. Start the production server:
+   ```bash
+   npm start
+   ```
+   The application will be available at `http://localhost:3000`.
+
+## Deploying to Render.com
+
+Render can automatically build and run the project using the provided `render.yaml` configuration.
+
+1. Push this repository to your own GitHub account.
+2. Log in to [Render](https://dashboard.render.com/) and create a **New Web Service** from your repository.
+3. Render will detect the `render.yaml` file and pre‑configure the service. Verify that the build command and start command match your setup (`npm run build` and `npm start`).
+4. Click **Create Web Service**. Render will install dependencies, build the React app, and start the Express server.
+5. Once the build is finished, Render will provide a public URL where the app is hosted.
+
+If you need to change the build or start commands, edit `render.yaml` accordingly and commit the changes.

--- a/package.json
+++ b/package.json
@@ -4,13 +4,17 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js",
+    "build": "echo \"Define your build command\"",
+    "serve": "node server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "openai": "^5.1.0"
+    "openai": "^5.1.0",
+    "express": "^4.18.2"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: ai-factory
+    env: node
+    plan: free
+    buildCommand: npm install && npm run build
+    startCommand: npm start

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const buildPath = path.join(__dirname, 'dist');
+app.use(express.static(buildPath));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(buildPath, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server to serve the built React app
- update `package.json` with server and build scripts
- provide `render.yaml` for Render.com deployment
- document local and Render deployment steps in new README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68410325f950832aa7f85189781d6bc5